### PR TITLE
Location first class

### DIFF
--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -47,31 +47,25 @@ LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `Item`.`name` IS NOT NULL THEN
             COUNT(`Item`.`name`) ELSE NULL END AS "Items"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `Item` ON
-        `Location`.`coordinate` = (CASE WHEN `Item`.`latitude`||`Item`.`longitude` IS NULL THEN
-            "~~" ELSE `Item`.`latitude`||`Item`.`longitude` END)
+        `Location`.`coordinate` = `Item`.`location`
     WHERE `Item`.`required` = 1
     GROUP BY
-        `Location`.`coordinate`) AS `RequiredItemLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `RequiredItemLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `Item`.`name` IS NOT NULL THEN
             COUNT(`Item`.`name`) ELSE NULL END AS "Items"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `Item` ON
-        `Location`.`coordinate` = (CASE WHEN `Item`.`latitude`||`Item`.`longitude` IS NULL THEN
-            "~~" ELSE `Item`.`latitude`||`Item`.`longitude` END)
+        `Location`.`coordinate` = `Item`.`location`
     WHERE `Item`.`required` = 0
     GROUP BY
-        `Location`.`coordinate`) AS `OptionalItemLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `OptionalItemLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -17,18 +17,8 @@ FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
 LEFT JOIN (SELECT
         `Location`.`coordinate`,
         `Island`.`name` AS "name"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
-    LEFT JOIN (SELECT *
-        FROM `Island`
-        UNION ALL SELECT
-            'various' AS 'name',
-            NULL AS 'longitude',
-            NULL AS 'latitude') AS 'Island' ON
-        `Location`.`coordinate` = (CASE WHEN `Island`.`latitude`||`Island`.`longitude` IS NULL THEN
-            "~~" ELSE `Island`.`latitude`||`Island`.`longitude` END)
+    FROM `Location` LEFT JOIN `Island` ON
+        `Location`.`coordinate` = `Island`.`location`
     GROUP BY
         `Location`.`coordinate`) AS `IslandLocation` USING(`coordinate`)
 
@@ -36,13 +26,9 @@ LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `HeartContainer`.`id` IS NOT NULL THEN
             COUNT(`HeartContainer`.`id`) ELSE NULL END AS "HeartContainers"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `HeartContainer` ON
-        `Location`.`coordinate` = (CASE WHEN `HeartContainer`.`latitude`||`HeartContainer`.`longitude` IS NULL THEN
-            "~~" ELSE `HeartContainer`.`latitude`||`HeartContainer`.`longitude` END)
+        `Location`.`coordinate` = `HeartContainer`.`location`
     GROUP BY
         `Location`.`coordinate`) AS `HeartContainerLocation` USING(`coordinate`)
 

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -13,8 +13,7 @@ FROM `Location`
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,
-        CASE WHEN `Island`.`name` IS NULL THEN
-            'various' ELSE `Island`.`name` END AS "name"
+        `Island`.`name`
     FROM `Location` LEFT JOIN `Island` ON
         `Location`.`coordinate` = `Island`.`location`
     GROUP BY
@@ -90,4 +89,53 @@ LEFT JOIN (SELECT
 USING(`coordinate`)
 
 GROUP BY
-    `Location`.`coordinate`;
+    `Location`.`coordinate`
+
+UNION ALL
+
+SELECT
+    "various" AS "name",
+    "~~" AS "coordinate",
+    (
+        SELECT
+            CASE WHEN `HeartContainer`.`id` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`HeartContainer`.`id`), -2, 2) ELSE NULL END
+        FROM `HeartContainer`
+        WHERE `HeartContainer`.`location` IS NULL
+    ) AS "HC",
+    (
+        SELECT
+            CASE WHEN `HeartPiece`.`id` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`HeartPiece`.`id`), -2, 2) ELSE NULL END
+        FROM `HeartPiece`
+        WHERE `HeartPiece`.`location` IS NULL
+    ) AS "HP",
+    (
+        SELECT
+            CASE WHEN `Item`.`name` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`Item`.`name`), -2, 2) ELSE NULL END
+        FROM `Item`
+        WHERE `Item`.`location` IS NULL AND `Item`.`required` = 1
+    ) AS "RI",
+    (
+        SELECT
+            CASE WHEN `Item`.`name` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`Item`.`name`), -2, 2) ELSE NULL END
+        FROM `Item`
+        WHERE `Item`.`location` IS NULL AND `Item`.`required` = 0
+    ) AS "OI",
+    (
+        SELECT
+            CASE WHEN `TreasureChart`.`number` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`TreasureChart`.`number`), -2, 2) ELSE NULL END
+        FROM `TreasureChart`
+        WHERE `TreasureChart`.`location` IS NULL
+    ) AS "TC",
+    (
+        SELECT
+            CASE WHEN `TriforceChart`.`number` IS NOT NULL THEN
+                SUBSTR('00' || COUNT(`TriforceChart`.`number`), -2, 2) ELSE NULL END
+        FROM `TriforceChart`
+        WHERE `TriforceChart`.`location` IS NULL
+    ) AS "TR";
+;

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -36,15 +36,12 @@ LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `HeartPiece`.`id` IS NOT NULL THEN
             COUNT(`HeartPiece`.`id`) ELSE NULL END AS "HeartPieces"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `HeartPiece` ON
-        `Location`.`coordinate` = (CASE WHEN `HeartPiece`.`latitude`||`HeartPiece`.`longitude` IS NULL THEN
-            "~~" ELSE `HeartPiece`.`latitude`||`HeartPiece`.`longitude` END)
+        `Location`.`coordinate` = `HeartPiece`.`location`
     GROUP BY
-        `Location`.`coordinate`) AS `HeartPieceLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `HeartPieceLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -9,18 +9,17 @@ SELECT
     SUBSTR('00' || `TreasureChartLocation`.`TreasureCharts`, -2, 2) AS "TC",
     SUBSTR('00' || `TriforceChartLocation`.`TriforceCharts`, -2, 2) AS "TR"
 
-FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-    FROM `Latitude` CROSS JOIN `Longitude`
-    UNION ALL
-    SELECT "~~" AS "coordinate") AS "Location"
+FROM `Location`
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,
-        `Island`.`name` AS "name"
+        CASE WHEN `Island`.`name` IS NULL THEN
+            'various' ELSE `Island`.`name` END AS "name"
     FROM `Location` LEFT JOIN `Island` ON
         `Location`.`coordinate` = `Island`.`location`
     GROUP BY
-        `Location`.`coordinate`) AS `IslandLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `IslandLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,
@@ -30,7 +29,8 @@ LEFT JOIN (SELECT
     LEFT JOIN `HeartContainer` ON
         `Location`.`coordinate` = `HeartContainer`.`location`
     GROUP BY
-        `Location`.`coordinate`) AS `HeartContainerLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `HeartContainerLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -82,15 +82,12 @@ LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `TriforceChart`.`number` IS NOT NULL THEN
             COUNT(`TriforceChart`.`number`) ELSE NULL END AS "TriforceCharts"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `TriforceChart` ON
-        `Location`.`coordinate` = (CASE WHEN `TriforceChart`.`latitude`||`TriforceChart`.`longitude` IS NULL THEN
-            "~~" ELSE `TriforceChart`.`latitude`||`TriforceChart`.`longitude` END)
+        `Location`.`coordinate` = `TriforceChart`.`location`
     GROUP BY
-        `Location`.`coordinate`) AS `TriforceChartLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `TriforceChartLocation`
+USING(`coordinate`)
 
 GROUP BY
     `Location`.`coordinate`;

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -71,15 +71,12 @@ LEFT JOIN (SELECT
         `Location`.`coordinate`,
         CASE WHEN `TreasureChart`.`number` IS NOT NULL THEN
             COUNT(`TreasureChart`.`number`) ELSE NULL END AS "TreasureCharts"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`
-        UNION ALL
-        SELECT "~~" AS "coordinate") AS "Location"
+    FROM `Location`
     LEFT JOIN `TreasureChart` ON
-        `Location`.`coordinate` = (CASE WHEN `TreasureChart`.`latitude`||`TreasureChart`.`longitude` IS NULL THEN
-            "~~" ELSE `TreasureChart`.`latitude`||`TreasureChart`.`longitude` END)
+        `Location`.`coordinate` = `TreasureChart`.`location`
     GROUP BY
-        `Location`.`coordinate`) AS `TreasureChartLocation` USING(`coordinate`)
+        `Location`.`coordinate`) AS `TreasureChartLocation`
+USING(`coordinate`)
 
 LEFT JOIN (SELECT
         `Location`.`coordinate`,

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -148,7 +148,7 @@ INSERT INTO `Island` (
 CREATE TABLE IF NOT EXISTS `HeartContainer`(
     `id` INTEGER PRIMARY KEY NOT NULL,
     `location` CHAR(2) NOT NULL,
-    `details` VARCHAR(255),
+    `details` VARCHAR(255) NOT NULL,
         FOREIGN KEY (`location`) REFERENCES `Location`(`coordinate`)
 );
 CREATE INDEX `heart_container_location` ON
@@ -169,62 +169,60 @@ INSERT INTO `HeartContainer` (
 --------------------
 CREATE TABLE IF NOT EXISTS `HeartPiece`(
     `id` INTEGER PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
-    `task` VARCHAR(255),
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+    `location` CHAR(2) NOT NULL,
+    `task` VARCHAR(255) NOT NULL,
+        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
-CREATE INDEX `heart_piece_coordinate` ON
-    `HeartPiece`(`latitude` || `longitude`);
+CREATE INDEX `heart_piece_location` ON
+    `HeartPiece`(`location`);
 
 INSERT INTO `HeartPiece` (
-    `latitude`, `longitude`, `task`
+    `location`, `task`
 ) VALUES
-    ('A', 1, "Locked in a jail cell; Use button to open door"),
-    ('A', 4, "Use Treasure Chart 38"),
-    ('A', 5, "Use Seagull to hit switch to put out flames"),
-    ('A', 6, "Use Treasure Chart 23"),
-    ('B', 1, "Clear the Secret Cave"),
-    ('B', 3, "950 Rupees at Beedle's Shop Ship"),
-    ('B', 3, "Use Treasure Chart 2"),
-    ('B', 3, "Defeat Cannon Boats and get from Light Ring"),
-    ('B', 4, "Use Deku Leaf from spiral island to ledge"),
-    ('B', 4, "Give Traveling Merchant a Shop Guru Statue"),
-    ('B', 7, "Hit Orca 500 times"),
-    ('B', 7, "Carry large pig to black dirt and use bait"),
-    ('B', 7, "Clear the Secret Cave (all 50 floors)"),
-    ('C', 2, "Win the Cannon Shoot mini-game (1st)"),
-    ('C', 3, "Defeat the Big Octo (12 eyes)"),
-    ('C', 5, "Destroy th Cannons on the Platform"),
-    ('C', 7, "Use Seagull to fetch from top of mountain"),
-    ('D', 2, "Win the hide-and-seek game with the kids"),
-    ('D', 2, "Win the Zee Fleet mini-game (1st)"),
-    ('D', 2, "Get the two people to start datig"),
-    ('D', 2, "Win the Auction (3rd item)"),
-    ('D', 2, "Decorate the town and talk to man on bench"),
-    ('D', 2, "Light the lighthouse; Talk to operator"),
-    ('D', 2, "Light the lighthouse; Chest on small island"),
-    ('D', 2, "Give Moe's letter to Maggie"),
-    ('D', 4, "Clear the Submarine"),
-    ('D', 6, "Use Treasure Chart 4"),
-    ('E', 1, "Use Treasure Chart 11"),
-    ('E', 2, "Use Treasure Chart 30"),
-    ('E', 2, "At the back of the Turtle Dome Secret Cave"),
-    ('E', 7, "Use Treasure Chart 15"),
-    ('E', 7, "On the top of the block-puzzle mountain"),
-    ('F', 1, "Defeat the Big Octo (12 eyes)"),
-    ('F', 2, "Letter after defeating Kalle Demos"),
-    ('F', 2, "Letter after delivering part-timer's letter"),
-    ('F', 2, "Letter after give 20 Golden Feathers to guard"),
-    ('F', 5, "Clear the Secret Cave"),
-    ('F', 5, "Use Treasure Chart 20"),
-    ('F', 6, "Complete the Wilted Deku Tree side quest"),
-    ('F', 6, "Use Treasure Chart 31"),
-    ('G', 2, "Win the Bird-Man Contest mini-game"),
-    ('G', 4, "Use Treasure Chart 5"),
-    ('G', 7, "Clear the Submarine"),
-    ('G', 7, "Use Treasure Chart 33")
+    ('A1', "Locked in a jail cell; Use button to open door"),
+    ('A4', "Use Treasure Chart 38"),
+    ('A5', "Use Seagull to hit switch to put out flames"),
+    ('A6', "Use Treasure Chart 23"),
+    ('B1', "Clear the Secret Cave"),
+    ('B3', "950 Rupees at Beedle's Shop Ship"),
+    ('B3', "Use Treasure Chart 2"),
+    ('B3', "Defeat Cannon Boats and get from Light Ring"),
+    ('B4', "Use Deku Leaf from spiral island to ledge"),
+    ('B4', "Give Traveling Merchant a Shop Guru Statue"),
+    ('B7', "Hit Orca 500 times"),
+    ('B7', "Carry large pig to black dirt and use bait"),
+    ('B7', "Clear the Secret Cave (all 50 floors)"),
+    ('C2', "Win the Cannon Shoot mini-game (1st)"),
+    ('C3', "Defeat the Big Octo (12 eyes)"),
+    ('C5', "Destroy th Cannons on the Platform"),
+    ('C7', "Use Seagull to fetch from top of mountain"),
+    ('D2', "Win the hide-and-seek game with the kids"),
+    ('D2', "Win the Zee Fleet mini-game (1st)"),
+    ('D2', "Get the two people to start datig"),
+    ('D2', "Win the Auction (3rd item)"),
+    ('D2', "Decorate the town and talk to man on bench"),
+    ('D2', "Light the lighthouse; Talk to operator"),
+    ('D2', "Light the lighthouse; Chest on small island"),
+    ('D2', "Give Moe's letter to Maggie"),
+    ('D4', "Clear the Submarine"),
+    ('D6', "Use Treasure Chart 4"),
+    ('E1', "Use Treasure Chart 11"),
+    ('E2', "Use Treasure Chart 30"),
+    ('E2', "At the back of the Turtle Dome Secret Cave"),
+    ('E7', "Use Treasure Chart 15"),
+    ('E7', "On the top of the block-puzzle mountain"),
+    ('F1', "Defeat the Big Octo (12 eyes)"),
+    ('F2', "Letter after defeating Kalle Demos"),
+    ('F2', "Letter after delivering part-timer's letter"),
+    ('F2', "Letter after give 20 Golden Feathers to guard"),
+    ('F5', "Clear the Secret Cave"),
+    ('F5', "Use Treasure Chart 20"),
+    ('F6', "Complete the Wilted Deku Tree side quest"),
+    ('F6', "Use Treasure Chart 31"),
+    ('G2', "Win the Bird-Man Contest mini-game"),
+    ('G4', "Use Treasure Chart 5"),
+    ('G7', "Clear the Submarine"),
+    ('G7', "Use Treasure Chart 33")
 ;
 
 -- Items

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -10,6 +10,8 @@ DROP TABLE IF EXISTS `Item`;
 DROP TABLE IF EXISTS `TreasureChart`;
 DROP TABLE IF EXISTS `TriforceChart`;
 
+DROP TABLE IF EXISTS `Location`;
+
 --------------------
 -- Map Coordinates
 --------------------
@@ -30,6 +32,34 @@ CREATE TABLE IF NOT EXISTS `Longitude`(
 );
 INSERT INTO `Longitude` ( `value` ) VALUES
     (1), (2), (3), (4), (5), (6), (7);
+
+-- Location
+--------------------
+CREATE TABLE IF NOT EXISTS `Location`(
+    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `coordinate` CHAR(2) NOT NULL,
+    `latitude` CHAR(1),
+    `longitude` UNSIGNED TINYINT(1),
+        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
+        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+);
+INSERT INTO `Location` (
+    `id`, `coordinate`, `latitude`, `longitude`
+)
+SELECT * FROM (SELECT
+    ROW_NUMBER() OVER() AS "id",
+    `Latitude`.`value`||`Longitude`.`value` AS "coordinate",
+    `Latitude`.`value` AS "latitude",
+    `Longitude`.`value` AS "longitude"
+FROM `Latitude` CROSS JOIN `Longitude`
+    ORDER BY `Latitude`.`value`, `Longitude`.`value`)
+UNION ALL
+SELECT
+    0    AS "id",
+    "~~" AS "coordinate",
+    NULL AS "latitude",
+    NULL AS "longitude"
+;
 
 -- Island
 --------------------

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -80,11 +80,11 @@ CREATE UNIQUE INDEX `island_location` ON
 INSERT INTO `Island` (
     `name`, `location`
 ) VALUES
-    ("various",     (SELECT
-                        `Location`.`coordinate`
-                    FROM `Location`
-                    WHERE `latitude`  IS NULL AND
-                          `longitude` IS NULL)),
+    -- ("various",     (SELECT
+    --                     `Location`.`coordinate`
+    --                 FROM `Location`
+    --                 WHERE `latitude`  IS NULL AND
+    --                       `longitude` IS NULL)),
 
     ("Forsaken Fortress",        'A1'),
     ("Four-Eye Reef",            'A2'),

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -39,8 +39,8 @@ INSERT INTO `Longitude` ( `value` ) VALUES
 CREATE TABLE IF NOT EXISTS `Location`(
     `id` INTEGER PRIMARY KEY NOT NULL,
     `coordinate` CHAR(2) NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
+    `latitude` CHAR(1) NOT NULL,
+    `longitude` UNSIGNED TINYINT(1) NOT NULL,
         FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
         FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
 );
@@ -52,19 +52,13 @@ CREATE UNIQUE INDEX `location_latitude_longitude` ON
 INSERT INTO `Location` (
     `id`, `coordinate`, `latitude`, `longitude`
 )
-SELECT * FROM (SELECT
+SELECT
     ROW_NUMBER() OVER() AS "id",
     `Latitude`.`value`||`Longitude`.`value` AS "coordinate",
     `Latitude`.`value` AS "latitude",
     `Longitude`.`value` AS "longitude"
 FROM `Latitude` CROSS JOIN `Longitude`
-    ORDER BY `Latitude`.`value`, `Longitude`.`value`)
-UNION ALL
-SELECT
-    0    AS "id",
-    "~~" AS "coordinate",
-    NULL AS "latitude",
-    NULL AS "longitude"
+    ORDER BY `Latitude`.`value`, `Longitude`.`value`
 ;
 
 -- Island
@@ -147,7 +141,7 @@ INSERT INTO `Island` (
 --------------------
 CREATE TABLE IF NOT EXISTS `HeartContainer`(
     `id` INTEGER PRIMARY KEY NOT NULL,
-    `location` CHAR(2) NOT NULL,
+    `location` CHAR(2),
     `details` VARCHAR(255) NOT NULL,
         FOREIGN KEY (`location`) REFERENCES `Location`(`coordinate`)
 );
@@ -169,7 +163,7 @@ INSERT INTO `HeartContainer` (
 --------------------
 CREATE TABLE IF NOT EXISTS `HeartPiece`(
     `id` INTEGER PRIMARY KEY NOT NULL,
-    `location` CHAR(2) NOT NULL,
+    `location` CHAR(2),
     `task` VARCHAR(255) NOT NULL,
         FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
@@ -229,7 +223,7 @@ INSERT INTO `HeartPiece` (
 --------------------
 CREATE TABLE IF NOT EXISTS `Item`(
     `name` VARCHAR(50) PRIMARY KEY NOT NULL,
-    `location` CHAR(2) NOT NULL,
+    `location` CHAR(2),
     `details` VARCHAR(255) NOT NULL,
     `required` BOOLEAN DEFAULT 1 NOT NULL,
         FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
@@ -269,9 +263,9 @@ INSERT INTO `Item` (
     ('E6', 1, "Iron Boots",             "Secret Cave"),
     ('D1', 1, "Hookshot",               "Wind Temple"),
     ('D1', 1, "Master Sword Restore 2", "Wind Temple"),
-    ('~~', 1, "Bait Bag",               "Beedle Shop Ship"),
+    (NULL, 1, "Bait Bag",               "Beedle Shop Ship"),
     ('D2', 1, "Cabana Deed",            "Mrs. Marie (20 Joy Pendants)"),
-    ('~~', 1, "Triforce of Courage",    "Triforce Chart x8"),
+    (NULL, 1, "Triforce of Courage",    "Triforce Chart x8"),
     ('D2', 0, "Deluxe Picto Box",       "Lenzo"),
     ('D2', 0, "Hero's Charm",           "Mrs. Marie (40 Joy Pendants)"),
     ('B3', 0, "Bottle 3",               "Beedle Special Shop (500 Rupees)"),
@@ -283,7 +277,7 @@ INSERT INTO `Item` (
 --------------------
 CREATE TABLE IF NOT EXISTS `TreasureChart`(
     `number` INTEGER PRIMARY KEY NOT NULL,
-    `location` CHAR(1) NOT NULL,
+    `location` CHAR(1),
     `details` VARCHAR(255) NOT NULL,
         FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
@@ -340,7 +334,7 @@ INSERT INTO `TreasureChart` (
 --------------------
 CREATE TABLE IF NOT EXISTS `TriforceChart`(
     `number` INTEGER PRIMARY KEY NOT NULL,
-    `location` CHAR(2) NOT NULL,
+    `location` CHAR(2),
     `details` VARCHAR(255) NOT NULL,
         FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
@@ -353,7 +347,7 @@ INSERT INTO `TriforceChart` (
     (01, 'B5', "Inside the ""Secret Cave"""),
     (02, 'E5', "Clear the Secret Cave (fireplace"),
     (03, 'G5', "Use Seagull to hit 5 switchs; In Secret Cave"),
-    (04, '~~', "Clear the Ghost Ship (G7,G3,B4,E1,A6,F5,C2)"),
+    (04, NULL, "Clear the Ghost Ship (G7,G3,B4,E1,A6,F5,C2)"),
     (05, 'A5', "Defeat Golden Cannon Boat; light ring"),
     (06, 'B7', "Clear the Secret Cave (level 30)"),
     (07, 'C5', "Clear the Secret Cave"),

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -228,58 +228,55 @@ INSERT INTO `HeartPiece` (
 -- Items
 --------------------
 CREATE TABLE IF NOT EXISTS `Item`(
-    -- `id` INTEGER PRIMARY KEY NOT NULL,
     `name` VARCHAR(50) PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
-    `details` VARCHAR(255),
+    `location` CHAR(2) NOT NULL,
+    `details` VARCHAR(255) NOT NULL,
     `required` BOOLEAN DEFAULT 1 NOT NULL,
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
-CREATE INDEX `item_coordinate` ON
-    `Item`(`latitude` || `longitude`);
+CREATE INDEX `item_location` ON
+    `Item`(`location`);
 
 INSERT INTO `Item` (
-    `latitude`, `longitude`, `required`, `name`, `details`
+    `location`, `required`, `name`, `details`
 ) VALUES
-    ('B', 7, 1, "Telescope",              "Aryll"),
-    ('B', 7, 1, "Hero's Sword",           "Orca"),
-    ('B', 7, 1, "Hero's Sheild",          "Granny"),
-    ('B', 7, 1, "Spoils Bag",             "Tetra's Pirate Ship - Niko's Rope Challenge"),
-    ('A', 1, 1, "Pirate's Charm",         "Tetra"),
-    ('D', 2, 1, "Sail",                   "Zunari (80 Rupees)"),
-    ('D', 2, 0, "Tingle Tuner",           "Tingle"),
-    ('D', 2, 0, "Picto Box",              "Tingle's cell maze"),
-    ('F', 2, 1, "Wind Waker",             "The King of Red Lions"),
-    ('F', 2, 1, "Delivery Bag",           "Quill"),
-    ('F', 2, 1, "Bottle 1",               "Medli"),
-    ('F', 2, 1, "Grappling Hook",         "Dragon Roost Cavern"),
-    ('F', 2, 1, "Din's Pearl",            "Komali"),
-    ('F', 5, 0, "Bottle 2",               "Submarine"),
-    ('F', 6, 1, "Deku Leaf",              "Great Deku Tree"),
-    ('F', 6, 1, "Boomerang",              "Forbidden Woods"),
-    ('F', 6, 1, "Farore's Pearl",         "Great Deku Tree"),
-    ('D', 2, 1, "Bombs",                  "Tetra's Pirate Ship - Niko's Rope Challenge"),
-    ('B', 7, 1, "Nayru's Pearl",          "Jabun"),
-    ('E', 4, 1, "Hero's Bow",             "Tower of the Gods"),
-    ('E', 4, 1, "Master Sword",           "Hyrule Castle"),
-    ('A', 1, 1, "Skull Hammer",           "Phantom Ganon"),
-    ('B', 2, 1, "Fire & Ice Arrows",      "Fairy Queen"),
-    ('F', 3, 1, "Power Bracelets",        "Secret Cave"),
-    ('C', 7, 1, "Mirror Shield",          "Earth Temple"),
-    ('C', 7, 1, "Master Sword Restore 1", "Earth Temple"),
-    ('E', 6, 1, "Iron Boots",             "Secret Cave"),
-    ('D', 1, 1, "Hookshot",               "Wind Temple"),
-    ('D', 1, 1, "Master Sword Restore 2", "Wind Temple"),
-    (NULL, NULL, 1, "Bait Bag",           "Beedle Shop Ship"),
-    ('D', 2, 1, "Cabana Deed",            "Mrs. Marie (20 Joy Pendants)"),
-    (NULL, NULL, 1, "Triforce of Courage", "Triforce Chart x8"),
-    ('D', 2, 0, "Deluxe Picto Box",       "Lenzo"),
-    ('D', 2, 0, "Hero's Charm",           "Mrs. Marie (40 Joy Pendants)"),
-    ('B', 3, 0, "Bottle 3",               "Beedle Special Shop (500 Rupees)"),
-    ('D', 2, 0, "Magic Armor",            "Zunari (Exotic Flower)"),
-    ('D', 2, 0, "Bottle 4",               "Mila")
+    ('B7', 1, "Telescope",              "Aryll"),
+    ('B7', 1, "Hero's Sword",           "Orca"),
+    ('B7', 1, "Hero's Sheild",          "Granny"),
+    ('B7', 1, "Spoils Bag",             "Tetra's Pirate Ship - Niko's Rope Challenge"),
+    ('A1', 1, "Pirate's Charm",         "Tetra"),
+    ('D2', 1, "Sail",                   "Zunari (80 Rupees)"),
+    ('D2', 0, "Tingle Tuner",           "Tingle"),
+    ('D2', 0, "Picto Box",              "Tingle's cell maze"),
+    ('F2', 1, "Wind Waker",             "The King of Red Lions"),
+    ('F2', 1, "Delivery Bag",           "Quill"),
+    ('F2', 1, "Bottle 1",               "Medli"),
+    ('F2', 1, "Grappling Hook",         "Dragon Roost Cavern"),
+    ('F2', 1, "Din's Pearl",            "Komali"),
+    ('F5', 0, "Bottle 2",               "Submarine"),
+    ('F6', 1, "Deku Leaf",              "Great Deku Tree"),
+    ('F6', 1, "Boomerang",              "Forbidden Woods"),
+    ('F6', 1, "Farore's Pearl",         "Great Deku Tree"),
+    ('D2', 1, "Bombs",                  "Tetra's Pirate Ship - Niko's Rope Challenge"),
+    ('B7', 1, "Nayru's Pearl",          "Jabun"),
+    ('E4', 1, "Hero's Bow",             "Tower of the Gods"),
+    ('E4', 1, "Master Sword",           "Hyrule Castle"),
+    ('A1', 1, "Skull Hammer",           "Phantom Ganon"),
+    ('B2', 1, "Fire & Ice Arrows",      "Fairy Queen"),
+    ('F3', 1, "Power Bracelets",        "Secret Cave"),
+    ('C7', 1, "Mirror Shield",          "Earth Temple"),
+    ('C7', 1, "Master Sword Restore 1", "Earth Temple"),
+    ('E6', 1, "Iron Boots",             "Secret Cave"),
+    ('D1', 1, "Hookshot",               "Wind Temple"),
+    ('D1', 1, "Master Sword Restore 2", "Wind Temple"),
+    ('~~', 1, "Bait Bag",               "Beedle Shop Ship"),
+    ('D2', 1, "Cabana Deed",            "Mrs. Marie (20 Joy Pendants)"),
+    ('~~', 1, "Triforce of Courage",    "Triforce Chart x8"),
+    ('D2', 0, "Deluxe Picto Box",       "Lenzo"),
+    ('D2', 0, "Hero's Charm",           "Mrs. Marie (40 Joy Pendants)"),
+    ('B3', 0, "Bottle 3",               "Beedle Special Shop (500 Rupees)"),
+    ('D2', 0, "Magic Armor",            "Zunari (Exotic Flower)"),
+    ('D2', 0, "Bottle 4",               "Mila")
 ;
 
 -- Treasure Charts

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -340,26 +340,24 @@ INSERT INTO `TreasureChart` (
 --------------------
 CREATE TABLE IF NOT EXISTS `TriforceChart`(
     `number` INTEGER PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
-    `details` VARCHAR(255),
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+    `location` CHAR(2) NOT NULL,
+    `details` VARCHAR(255) NOT NULL,
+        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
-CREATE INDEX `triforce_chart_coordinate` ON
-    `TriforceChart`(`latitude` || `longitude`);
+CREATE INDEX `triforce_chart_location` ON
+    `TriforceChart`(`location`);
 
 INSERT INTO `TriforceChart` (
-    `number`, `latitude`, `longitude`, `details`
+    `number`, `location`, `details`
 ) VALUES
-    (01, 'B', 5, "Inside the ""Secret Cave"""),
-    (02, 'E', 5, "Clear the Secret Cave (fireplace"),
-    (03, 'G', 5, "Use Seagull to hit 5 switchs; In Secret Cave"),
-    (04, NULL, NULL, "Clear the Ghost Ship (G7,G3,B4,E1,A6,F5,C2)"),
-    (05, 'A', 5, "Defeat Golden Cannon Boat; light ring"),
-    (06, 'B', 7, "Clear the Secret Cave (level 30)"),
-    (07, 'C', 5, "Clear the Secret Cave"),
-    (08, 'G', 1, "Clear the Secret Cave")
+    (01, 'B5', "Inside the ""Secret Cave"""),
+    (02, 'E5', "Clear the Secret Cave (fireplace"),
+    (03, 'G5', "Use Seagull to hit 5 switchs; In Secret Cave"),
+    (04, '~~', "Clear the Ghost Ship (G7,G3,B4,E1,A6,F5,C2)"),
+    (05, 'A5', "Defeat Golden Cannon Boat; light ring"),
+    (06, 'B7', "Clear the Secret Cave (level 30)"),
+    (07, 'C5', "Clear the Secret Cave"),
+    (08, 'G1', "Clear the Secret Cave")
 ;
 
 END;

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -1,7 +1,6 @@
 -- Zelda Wind Waker Checklist
-BEGIN;
-
 PRAGMA foreign_keys = ON;
+BEGIN;
 
 DROP TABLE IF EXISTS `Island`;
 DROP TABLE IF EXISTS `HeartContainer`;
@@ -36,13 +35,18 @@ INSERT INTO `Longitude` ( `value` ) VALUES
 -- Location
 --------------------
 CREATE TABLE IF NOT EXISTS `Location`(
-    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `id` INTEGER PRIMARY KEY NOT NULL,
     `coordinate` CHAR(2) NOT NULL,
     `latitude` CHAR(1),
     `longitude` UNSIGNED TINYINT(1),
         FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
         FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
 );
+CREATE UNIQUE INDEX `location_coordinate` ON
+    `Location`(`coordinate`);
+CREATE UNIQUE INDEX `location_latitude_longitude` ON
+    `Location`(`latitude`, `longitude`);
+
 INSERT INTO `Location` (
     `id`, `coordinate`, `latitude`, `longitude`
 )
@@ -64,76 +68,71 @@ SELECT
 -- Island
 --------------------
 CREATE TABLE IF NOT EXISTS `Island`(
-    -- `id` INTEGER PRIMARY KEY NOT NULL,
     `name` VARCHAR(200) PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1) NOT NULL,
-    `longitude` UNSIGNED TINYINT(1) NOT NULL,
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+    `location` CHAR(2) NOT NULL,
+        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
-CREATE UNIQUE INDEX `island_coordinate` ON
-    `Island`(`latitude` || `longitude`);
-CREATE UNIQUE INDEX `island_name` ON
-    `Island`(`name`);
+CREATE UNIQUE INDEX `island_location` ON
+    `Island`(`location`);
 
 INSERT INTO `Island` (
-    `name`, `latitude`, `longitude`
+    `name`, `location`
 ) VALUES
-    ("Forsaken Fortress",        'A', 1),
-    ("Four-Eye Reef",            'A', 2),
-    ("Western Fairy Island",     'A', 3),
-    ("Three-Eye Reef",           'A', 4),
-    ("Needle Rock Isle",         'A', 5),
-    ("Diamond Steppe Island",    'A', 6),
-    ("Horseshoe Island",         'A', 7),
+    ("Forsaken Fortress",        'A1'),
+    ("Four-Eye Reef",            'A2'),
+    ("Western Fairy Island",     'A3'),
+    ("Three-Eye Reef",           'A4'),
+    ("Needle Rock Isle",         'A5'),
+    ("Diamond Steppe Island",    'A6'),
+    ("Horseshoe Island",         'A7'),
 
-    ("Star Island",              'B', 1),
-    ("Mother & Child Isles",     'B', 2),
-    ("Rock Spire Island",        'B', 3),
-    ("Greatfish Island",         'B', 4),
-    ("Islet of Steel",           'B', 5),
-    ("Five-Eye Reef",            'B', 6),
-    ("Outset Island",            'B', 7),
+    ("Star Island",              'B1'),
+    ("Mother & Child Isles",     'B2'),
+    ("Rock Spire Island",        'B3'),
+    ("Greatfish Island",         'B4'),
+    ("Islet of Steel",           'B5'),
+    ("Five-Eye Reef",            'B6'),
+    ("Outset Island",            'B7'),
 
-    ("Northern Fairy Island",    'C', 1),
-    ("Spectacle Island",         'C', 2),
-    ("Tingle Island",            'C', 3),
-    ("Cyclops Reef",             'C', 4),
-    ("Stone Watcher Island",     'C', 5),
-    ("Shark Island",             'C', 6),
-    ("Headstone Island",         'C', 7),
+    ("Northern Fairy Island",    'C1'),
+    ("Spectacle Island",         'C2'),
+    ("Tingle Island",            'C3'),
+    ("Cyclops Reef",             'C4'),
+    ("Stone Watcher Island",     'C5'),
+    ("Shark Island",             'C6'),
+    ("Headstone Island",         'C7'),
 
-    ("Gale Isle",                'D', 1),
-    ("Windfall Island",          'D', 2),
-    ("Northern Triangle Island", 'D', 3),
-    ("Six-Eye Reef",             'D', 4),
-    ("Southern Triangle Island", 'D', 5),
-    ("Southern Fairy Island",    'D', 6),
-    ("Two-Eye Reef",             'D', 7),
+    ("Gale Isle",                'D1'),
+    ("Windfall Island",          'D2'),
+    ("Northern Triangle Island", 'D3'),
+    ("Six-Eye Reef",             'D4'),
+    ("Southern Triangle Island", 'D5'),
+    ("Southern Fairy Island",    'D6'),
+    ("Two-Eye Reef",             'D7'),
 
-    ("Crescent Moon Island",     'E', 1),
-    ("Pawprint Isle",            'E', 2),
-    ("Eastern Fairy Island",     'E', 3),
-    ("Tower of the Gods",        'E', 4),
-    ("Private Oasis",            'E', 5),
-    ("Ice Ring Isle",            'E', 6),
-    ("Angular Isles",            'E', 7),
+    ("Crescent Moon Island",     'E1'),
+    ("Pawprint Isle",            'E2'),
+    ("Eastern Fairy Island",     'E3'),
+    ("Tower of the Gods",        'E4'),
+    ("Private Oasis",            'E5'),
+    ("Ice Ring Isle",            'E6'),
+    ("Angular Isles",            'E7'),
 
-    ("Seven-Star Isles",         'F', 1),
-    ("Dragon Roost Island",      'F', 2),
-    ("Fire Mountain",            'F', 3),
-    ("Eastern Triangle Island",  'F', 4),
-    ("Bomb Island",              'F', 5),
-    ("Forest Haven",             'F', 6),
-    ("Boating Course",           'F', 7),
+    ("Seven-Star Isles",         'F1'),
+    ("Dragon Roost Island",      'F2'),
+    ("Fire Mountain",            'F3'),
+    ("Eastern Triangle Island",  'F4'),
+    ("Bomb Island",              'F5'),
+    ("Forest Haven",             'F6'),
+    ("Boating Course",           'F7'),
 
-    ("Overlook Island",          'G', 1),
-    ("Flight Control Platform",  'G', 2),
-    ("Star Belt Archipelago",    'G', 3),
-    ("Thorned Fairy Island",     'G', 4),
-    ("Bird's Peak Rock",         'G', 5),
-    ("Cliff Plateau Isles",      'G', 6),
-    ("Five-Star Isles",          'G', 7)
+    ("Overlook Island",          'G1'),
+    ("Flight Control Platform",  'G2'),
+    ("Star Belt Archipelago",    'G3'),
+    ("Thorned Fairy Island",     'G4'),
+    ("Bird's Peak Rock",         'G5'),
+    ("Cliff Plateau Isles",      'G6'),
+    ("Five-Star Isles",          'G7')
 ;
 
 -- Heart Containers

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -1,5 +1,7 @@
 -- Zelda Wind Waker Checklist
+
 PRAGMA foreign_keys = ON;
+
 BEGIN;
 
 DROP TABLE IF EXISTS `Island`;
@@ -70,7 +72,7 @@ SELECT
 CREATE TABLE IF NOT EXISTS `Island`(
     `name` VARCHAR(200) PRIMARY KEY NOT NULL,
     `location` CHAR(2) NOT NULL,
-        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
+        FOREIGN KEY (`location`) REFERENCES `Location`(`coordinate`)
 );
 CREATE UNIQUE INDEX `island_location` ON
     `Island`(`location`);
@@ -78,6 +80,12 @@ CREATE UNIQUE INDEX `island_location` ON
 INSERT INTO `Island` (
     `name`, `location`
 ) VALUES
+    ("various",     (SELECT
+                        `Location`.`coordinate`
+                    FROM `Location`
+                    WHERE `latitude`  IS NULL AND
+                          `longitude` IS NULL)),
+
     ("Forsaken Fortress",        'A1'),
     ("Four-Eye Reef",            'A2'),
     ("Western Fairy Island",     'A3'),
@@ -139,24 +147,22 @@ INSERT INTO `Island` (
 --------------------
 CREATE TABLE IF NOT EXISTS `HeartContainer`(
     `id` INTEGER PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
+    `location` CHAR(2) NOT NULL,
     `details` VARCHAR(255),
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+        FOREIGN KEY (`location`) REFERENCES `Location`(`coordinate`)
 );
-CREATE INDEX `heart_container_coordinate` ON
-    `HeartContainer`(`latitude` || `longitude`);
+CREATE INDEX `heart_container_location` ON
+    `HeartContainer`(`location`);
 
 INSERT INTO `HeartContainer` (
-    `latitude`, `longitude`, `details`
+    `location`, `details`
 ) VALUES
-    ('F', 2, "Dragon Roost Cavern"),
-    ('F', 6, "Forbidden Woods"),
-    ('E', 4, "Tower of the Gods"),
-    ('A', 1, "2nd visit"),
-    ('C', 7, "Earth Temple"),
-    ('D', 1, "Wind Temple")
+    ('F2', "Dragon Roost Cavern"),
+    ('F6', "Forbidden Woods"),
+    ('E4', "Tower of the Gods"),
+    ('A1', "2nd visit"),
+    ('C7', "Earth Temple"),
+    ('D1', "Wind Temple")
 ;
 
 -- Heart Pieces

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -283,59 +283,57 @@ INSERT INTO `Item` (
 --------------------
 CREATE TABLE IF NOT EXISTS `TreasureChart`(
     `number` INTEGER PRIMARY KEY NOT NULL,
-    `latitude` CHAR(1),
-    `longitude` UNSIGNED TINYINT(1),
-    `details` VARCHAR(255),
-        FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
+    `location` CHAR(1) NOT NULL,
+    `details` VARCHAR(255) NOT NULL,
+        FOREIGN KEY (`location`)  REFERENCES `Location`(`coordinate`)
 );
-CREATE INDEX `treasure_chart_coordinate` ON
-    `TreasureChart`(`latitude` || `longitude`);
+CREATE INDEX `treasure_chart_location` ON
+    `TreasureChart`(`location`);
 
 INSERT INTO `TreasureChart` (
-    `number`, `latitude`, `longitude`, `details`
+    `number`, `location`, `details`
 ) VALUES
-    (01, 'F', 6, "In Forbidden Woods"),
-    (02, 'D', 2, "Give Maggie's Father 20 Skull Necklaces"),
-    (03, 'F', 6, "Small island outside Forest Haven, Deku Leaf"),
-    (04, 'B', 3, "Beedle Special Shop (900 Rupees)"),
-    (05, 'D', 1, "In Wind Temple"),
-    (06, 'E', 4, "In Tower of the Gods"),
-    (07, 'D', 2, "Win the Zee Fleet mini-game (2nd)"),
-    (08, 'A', 7, "Clear the Secret Cave"),
-    (09, 'E', 1, "Clear the Submarine"),
-    (10, 'E', 1, "Sitting on the island"),
-    (11, 'F', 2, "In Dragon Roost Cavern"),
-    (12, 'C', 7, "In Earth Temple"),
-    (13, 'D', 7, "Clear the artillery from the reef"),
-    (14, 'C', 7, "Clear the Submarine"),
-    (15, 'F', 6, "In Forbidden Woods"),
-    (16, 'F', 1, "Clear the Platforms"),
-    (17, 'C', 2, "Win the Cannon Shoot mini-game (2nd)"),
-    (18, 'D', 2, "Win the Auction (2nd)"),
-    (19, 'A', 2, "Clear all artillery from the reef"),
-    (20, 'C', 7, "In Earth Temple"),
-    (21, 'C', 4, "Clear all artillery from the reef"),
-    (22, 'C', 1, "Clear the Submarine"),
-    (23, 'D', 2, "Win the Zee Fleet mini-game (3rd)"),
-    (24, 'D', 2, "Show Lenzo & friend picto to gossip ladies"),
-    (25, 'G', 6, "Use Secret Cave to reach it on high cliff"),
-    (26, 'D', 4, "Clear all artillery from the reef"),
-    (27, 'E', 5, "On top of the cliff"),
-    (28, 'A', 7, "Finish the ""Golf"" game with the Boko Nuts"),
-    (29, 'D', 2, "Secret room in Lenzo's house"),
-    (30, 'E', 4, "In Tower of the Gods"),
-    (31, 'D', 2, "Show full moon picto to man on steps"),
-    (32, 'A', 4, "Clear all artillery from the reef"),
-    (33, 'D', 2, "Show picto of old beauty queen to herself"),
-    (34, 'F', 4, "Given by Salvage Corp."),
-    (35, 'D', 1, "In Wind Temple"),
-    (36, 'E', 6, "Use Fire Arrows on iced chest"),
-    (37, 'B', 3, "Clear the Secret Cave"),
-    (38, 'D', 2, "Win the Auction (1st)"),
-    (39, 'F', 2, "In Dragon Roost Cavern"),
-    (40, 'D', 6, "Clear the Platforms"),
-    (41, 'B', 6, "Clear the artillery from the reef")
+    (01, 'F6', "In Forbidden Woods"),
+    (02, 'D2', "Give Maggie's Father 20 Skull Necklaces"),
+    (03, 'F6', "Small island outside Forest Haven, Deku Leaf"),
+    (04, 'B3', "Beedle Special Shop (900 Rupees)"),
+    (05, 'D1', "In Wind Temple"),
+    (06, 'E4', "In Tower of the Gods"),
+    (07, 'D2', "Win the Zee Fleet mini-game (2nd)"),
+    (08, 'A7', "Clear the Secret Cave"),
+    (09, 'E1', "Clear the Submarine"),
+    (10, 'E1', "Sitting on the island"),
+    (11, 'F2', "In Dragon Roost Cavern"),
+    (12, 'C7', "In Earth Temple"),
+    (13, 'D7', "Clear the artillery from the reef"),
+    (14, 'C7', "Clear the Submarine"),
+    (15, 'F6', "In Forbidden Woods"),
+    (16, 'F1', "Clear the Platforms"),
+    (17, 'C2', "Win the Cannon Shoot mini-game (2nd)"),
+    (18, 'D2', "Win the Auction (2nd)"),
+    (19, 'A2', "Clear all artillery from the reef"),
+    (20, 'C7', "In Earth Temple"),
+    (21, 'C4', "Clear all artillery from the reef"),
+    (22, 'C1', "Clear the Submarine"),
+    (23, 'D2', "Win the Zee Fleet mini-game (3rd)"),
+    (24, 'D2', "Show Lenzo & friend picto to gossip ladies"),
+    (25, 'G6', "Use Secret Cave to reach it on high cliff"),
+    (26, 'D4', "Clear all artillery from the reef"),
+    (27, 'E5', "On top of the cliff"),
+    (28, 'A7', "Finish the ""Golf"" game with the Boko Nuts"),
+    (29, 'D2', "Secret room in Lenzo's house"),
+    (30, 'E4', "In Tower of the Gods"),
+    (31, 'D2', "Show full moon picto to man on steps"),
+    (32, 'A4', "Clear all artillery from the reef"),
+    (33, 'D2', "Show picto of old beauty queen to herself"),
+    (34, 'F4', "Given by Salvage Corp."),
+    (35, 'D1', "In Wind Temple"),
+    (36, 'E6', "Use Fire Arrows on iced chest"),
+    (37, 'B3', "Clear the Secret Cave"),
+    (38, 'D2', "Win the Auction (1st)"),
+    (39, 'F2', "In Dragon Roost Cavern"),
+    (40, 'D6', "Clear the Platforms"),
+    (41, 'B6', "Clear the artillery from the reef")
 ;
 
 -- Triforce Charts


### PR DESCRIPTION
Create a location table and use it instead of combining latitude and longitude everywhere.
While that was a creative move in SQLite, the reality is, that some items, features, etc. do not all have a location. Longitude and Latitude may **both** be set to `NULL` to convey that; But it should not be allowed that one can be `NULL` without the other. Strips of the map don't necessarily make sense. And the second they do make sense, we can just add that record to the `Location` table itself.

The same anomaly however is still possible in this schema. Bogus data can simply be added to the Location table and then anything in another table with a location column can just reference it… There is no way to make a table READ ONLY I don't think; Nor does that seem like the correct solution.

What is really needed is a solution that allows the location itself to be `NULL`, never latitude or longitude. The thing about this is, `FULL OUTER JOINS` still are not supported by SQLite.

We do accomplish that here, albeit with some caveats; Mostly surrounding the complexity of the `island-tasks.sql`.