### PR TITLE
Add OtherChart Table

### DIFF
--- a/sql/heart-piece-locations.sql
+++ b/sql/heart-piece-locations.sql
@@ -1,5 +1,0 @@
-.width 2 %
-SELECT `Location`.`coordinate`, `HeartPiece`.`task` AS "Heart Piece"
-    FROM (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`) AS "Location" LEFT JOIN `HeartPiece` ON
-            `Location`.`coordinate` = `HeartPiece`.`latitude`||`HeartPiece`.`longitude`;

--- a/sql/heart-pieces.sql
+++ b/sql/heart-pieces.sql
@@ -1,2 +1,5 @@
-.width 2 47
-SELECT `latitude` || `longitude` AS "coordinates", `task` FROM `HeartPiece`;
+-- .width 2 47
+SELECT
+    `location` AS "coordinates",
+    `task`
+FROM `HeartPiece`;

--- a/sql/island-tasks.sql
+++ b/sql/island-tasks.sql
@@ -1,4 +1,4 @@
-.width 24 2 2 2 2 2 2 2 2 %
+-- .width 24 2 2 2 2 2 2 2 2 %
 SELECT
     `IslandLocation`.`name`,
     `Location`.`coordinate`,
@@ -158,5 +158,5 @@ SELECT
                 SUBSTR('00' || COUNT(`SunkenTreasure`.`number`), -2, 2) ELSE NULL END
         FROM `SunkenTreasure`
         WHERE `SunkenTreasure`.`location` IS NULL
-    ) AS "ST";
+    ) AS "ST"
 ;

--- a/sql/items.sql
+++ b/sql/items.sql
@@ -1,4 +1,8 @@
-.width 2 22 45 3
-SELECT `latitude` || `longitude` AS "coordinates", `name`, `details`,
-    CASE WHEN `required` THEN '' ELSE 'Optional' END AS "required"
+-- .width 2 22 45 3
+SELECT
+    `location` AS "coordinates",
+    `name`,
+    `details`,
+    CASE WHEN `required` THEN
+        '' ELSE 'Optional' END AS "required"
 FROM `Item`;

--- a/sql/locations.sql
+++ b/sql/locations.sql
@@ -1,4 +1,0 @@
-.width %
-SELECT * FROM
-    (SELECT `Latitude`.`value`||`Longitude`.`value` AS "coordinate"
-        FROM `Latitude` CROSS JOIN `Longitude`) AS "Location";

--- a/sql/sunken-treasure-other-charts.sql
+++ b/sql/sunken-treasure-other-charts.sql
@@ -1,0 +1,10 @@
+SELECT
+    `OtherChart`.`name` AS "Sunken Chart",
+    `SunkenTreasure`.`location`,
+    `SunkenTreasure`.`chart_number` AS "Use Chart #"
+FROM `SunkenTreasure`
+INNER JOIN `SunkenChart` ON
+    `SunkenTreasure`.`number` = `SunkenChart`.`sunkenTreasureNumber`
+INNER JOIN `OtherChart` ON
+    `SunkenChart`.`otherChartNumber` = `OtherChart`.`number`
+ORDER BY `SunkenTreasure`.`location`;

--- a/sql/sunken-treasure.sql
+++ b/sql/sunken-treasure.sql
@@ -1,0 +1,19 @@
+-- .width 20 %
+SELECT
+    `SunkenTreasure`.`number`,
+    `SunkenTreasure`.`treasure`,
+    SUBSTR('00' || COUNT(`SunkenTreasure`.`number`), -2, 2) AS "count"
+FROM `SunkenTreasure`
+GROUP BY `SunkenTreasure`.`treasure`;
+
+-- .width 2 2 20 2 %
+SELECT
+    SUBSTR('00' || `SunkenTreasure`.`number`, -2, 2) AS "#",
+    `SunkenTreasure`.`location`,
+    `SunkenTreasure`.`treasure`,
+    CASE WHEN `Chart`.`location` IS NULL THEN
+        '~~' ELSE `Chart`.`location` END AS "Chart Location"
+FROM `SunkenTreasure`
+LEFT JOIN `Chart` ON
+    `SunkenTreasure`.`chart_number` = `Chart`.`number` AND
+    `SunkenTreasure`.`chart_type`   = `Chart`.`type`;

--- a/sql/treasure-charts.sql
+++ b/sql/treasure-charts.sql
@@ -1,2 +1,10 @@
-.width 2 2 45
-SELECT `latitude` || `longitude` AS "coordinates", SUBSTR('00' || `number`, -2, 2) AS "#", `details` FROM `TreasureChart`;
+-- .width 2 2 45
+SELECT
+    `location` AS "coordinates",
+    SUBSTR('00' || `number`, -2, 2) AS "#",
+    `details`
+FROM `Chart`
+LEFT JOIN `Location` ON
+    `Chart`.`location` = `Location`.`coordinate`
+WHERE `type` = "Treasure"
+ORDER BY `latitude`, `longitude`;

--- a/zww-checklist-schema.sql
+++ b/zww-checklist-schema.sql
@@ -10,29 +10,31 @@ DROP TABLE IF EXISTS `HeartPiece`;
 DROP TABLE IF EXISTS `Item`;
 DROP TABLE IF EXISTS `Chart`;
 DROP TABLE IF EXISTS `ChartType`;
+DROP TABLE IF EXISTS `SunkenTreasureOtherChart`;
 DROP TABLE IF EXISTS `SunkenTreasure`;
+DROP TABLE IF EXISTS `OtherChart`;
 
 DROP TABLE IF EXISTS `Location`;
 
 --------------------
 -- Map Coordinates
 --------------------
--- Latitude
---------------------
-DROP TABLE IF EXISTS `Latitude`;
-CREATE TABLE IF NOT EXISTS `Latitude`(
-    `value` CHAR(1) PRIMARY KEY NOT NULL
-);
-INSERT INTO `Latitude` ( `value` ) VALUES
-    ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');
-
 -- Longitude
 --------------------
 DROP TABLE IF EXISTS `Longitude`;
 CREATE TABLE IF NOT EXISTS `Longitude`(
-    `value` UNSIGNED TINYINT(1) PRIMARY KEY NOT NULL
+    `value` CHAR(1) PRIMARY KEY NOT NULL
 );
 INSERT INTO `Longitude` ( `value` ) VALUES
+    ('A'), ('B'), ('C'), ('D'), ('E'), ('F'), ('G');
+
+-- Latitude
+--------------------
+DROP TABLE IF EXISTS `Latitude`;
+CREATE TABLE IF NOT EXISTS `Latitude`(
+    `value` UNSIGNED TINYINT(1) PRIMARY KEY NOT NULL
+);
+INSERT INTO `Latitude` ( `value` ) VALUES
     (1), (2), (3), (4), (5), (6), (7);
 
 -- Location
@@ -40,26 +42,26 @@ INSERT INTO `Longitude` ( `value` ) VALUES
 CREATE TABLE IF NOT EXISTS `Location`(
     `id` INTEGER PRIMARY KEY NOT NULL,
     `coordinate` CHAR(2) NOT NULL,
-    `latitude` CHAR(1) NOT NULL,
     `longitude` UNSIGNED TINYINT(1) NOT NULL,
+    `latitude` CHAR(1) NOT NULL,
+        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`),
         FOREIGN KEY (`latitude`)  REFERENCES `Latitude`(`value`)
-        FOREIGN KEY (`longitude`) REFERENCES `Longitude`(`value`)
 );
 CREATE UNIQUE INDEX `location_coordinate` ON
     `Location`(`coordinate`);
-CREATE UNIQUE INDEX `location_latitude_longitude` ON
-    `Location`(`latitude`, `longitude`);
+CREATE UNIQUE INDEX `location_longitude_latitude` ON
+    `Location`(`longitude`, `latitude`);
 
 INSERT INTO `Location` (
-    `id`, `coordinate`, `latitude`, `longitude`
+    `id`, `coordinate`, `longitude`, `latitude`
 )
 SELECT
     ROW_NUMBER() OVER() AS "id",
-    `Latitude`.`value`||`Longitude`.`value` AS "coordinate",
-    `Latitude`.`value` AS "latitude",
-    `Longitude`.`value` AS "longitude"
-FROM `Latitude` CROSS JOIN `Longitude`
-    ORDER BY `Latitude`.`value`, `Longitude`.`value`
+    `Longitude`.`value`||`Latitude`.`value` AS "coordinate",
+    `Longitude`.`value` AS "longitude",
+    `Latitude`.`value` AS "latitude"
+FROM `Longitude` CROSS JOIN `Latitude`
+    ORDER BY `Longitude`.`value`, `Latitude`.`value`
 ;
 
 -- Island
@@ -366,56 +368,125 @@ CREATE INDEX `sunken_treasure_location` ON
 
 INSERT INTO `SunkenTreasure` (
     `number`, `location`, `chart_number`, `chart_type`, `treasure`
-) VALUES 
-    (01, 'A1', 25, 'Treasure', '200 Rupees'),
-    (02, 'A2', 41, 'Treasure', 'Great Fairy Chart'),
-    (03, 'A3', 08, 'Treasure', '200 Rupees'),
-    (04, 'A4', 38, 'Treasure', 'Heart Piece'),
-    (05, 'A5', 28, 'Treasure', '200 Rupees'),
-    (06, 'A6', 23, 'Treasure', 'Heart Piece'),
-    (07, 'A7', 09, 'Treasure', '200 Rupees'),
-    (08, 'B1', 07, 'Treasure', '200 Rupees'),
-    (09, 'B2', 29, 'Treasure', '200 Rupees'),
-    (10, 'B3', 02, 'Treasure', 'Heart Piece'),
-    (11, 'B4', 01, 'Triforce', 'Triforce Shard'),
-    (12, 'B5', 35, 'Treasure', '200 Rupees'),
-    (13, 'B6', 12, 'Treasure', '200 Rupees'),
-    (14, 'B7', 04, 'Triforce', 'Triforce Shard'),
-    (15, 'C1', 24, 'Treasure', '200 Rupees'),
-    (16, 'C2', 22, 'Treasure', '200 Rupees'),
-    (17, 'C3', 10, 'Treasure', '200 Rupees'),
-    (18, 'C4', 21, 'Treasure', 'Light Ring Chart'),
-    (19, 'C5', 03, 'Triforce', 'Triforce Shard'),
-    (20, 'C6', 16, 'Treasure', '200 Rupees'),
-    (21, 'C7', 40, 'Treasure', '200 Rupees'),
-    (22, 'D1', 02, 'Triforce', 'Triforce Shard'),
-    (23, 'D2', 18, 'Treasure', '1 Rupee'),
-    (24, 'D3', 26, 'Treasure', 'Octo Chart'),
-    (25, 'D4', 06, 'Treasure', '200 Rupees'),
-    (26, 'D5', 06, 'Triforce', 'Triforce Shard'),
-    (27, 'D6', 04, 'Treasure', 'Heart Piece'),
-    (28, 'D7', 08, 'Triforce', 'Triforce Shard'),
-    (29, 'E1', 11, 'Treasure', 'Heart Piece'),
-    (30, 'E2', 30, 'Treasure', 'Heart Piece'),
-    (31, 'E3', 03, 'Treasure', '200 Rupees'),
-    (32, 'E4', 14, 'Treasure', '200 Rupees'),
-    (33, 'E5', 01, 'Treasure', '200 Rupees'),
-    (34, 'E6', 17, 'Treasure', '200 Rupees'),
-    (35, 'E7', 15, 'Treasure', 'Heart Piece'),
-    (36, 'F1', 07, 'Triforce', 'Triforce Shard'),
-    (37, 'F2', 39, 'Treasure', '200 Rupees'),
-    (38, 'F3', 37, 'Treasure', '200 Rupees'),
-    (39, 'F4', 34, 'Treasure', '200 Rupees'),
-    (40, 'F5', 20, 'Treasure', 'Heart Piece'),
-    (41, 'F6', 31, 'Treasure', 'Heart Piece'),
-    (42, 'F7', 32, 'Treasure', 'Sea Hearts Chart'),
-    (43, 'G1', 13, 'Treasure', 'Secret Cave Chart'),
-    (44, 'G2', 19, 'Treasure', 'Hearts Chart'),
-    (45, 'G3', 27, 'Treasure', '200 Rupees'),
-    (46, 'G4', 05, 'Treasure', 'Heart Piece'),
-    (47, 'G5', 36, 'Treasure', '200 Rupees'),
-    (48, 'G6', 05, 'Triforce', 'Triforce Shard'),
-    (49, 'G7', 33, 'Treasure', 'Heart Piece')
+) VALUES
+    (01, 'A1', 25, 'Treasure', "200 Rupees"),
+    (02, 'A2', 41, 'Treasure', "Great Fairy Chart"),
+    (03, 'A3', 08, 'Treasure', "200 Rupees"),
+    (04, 'A4', 38, 'Treasure', "Heart Piece"),
+    (05, 'A5', 28, 'Treasure', "200 Rupees"),
+    (06, 'A6', 23, 'Treasure', "Heart Piece"),
+    (07, 'A7', 09, 'Treasure', "200 Rupees"),
+    (08, 'B1', 07, 'Treasure', "200 Rupees"),
+    (09, 'B2', 29, 'Treasure', "200 Rupees"),
+    (10, 'B3', 02, 'Treasure', "Heart Piece"),
+    (11, 'B4', 01, 'Triforce', "Triforce Shard"),
+    (12, 'B5', 35, 'Treasure', "200 Rupees"),
+    (13, 'B6', 12, 'Treasure', "200 Rupees"),
+    (14, 'B7', 04, 'Triforce', "Triforce Shard"),
+    (15, 'C1', 24, 'Treasure', "200 Rupees"),
+    (16, 'C2', 22, 'Treasure', "200 Rupees"),
+    (17, 'C3', 10, 'Treasure', "200 Rupees"),
+    (18, 'C4', 21, 'Treasure', "Light Ring Chart"),
+    (19, 'C5', 03, 'Triforce', "Triforce Shard"),
+    (20, 'C6', 16, 'Treasure', "200 Rupees"),
+    (21, 'C7', 40, 'Treasure', "200 Rupees"),
+    (22, 'D1', 02, 'Triforce', "Triforce Shard"),
+    (23, 'D2', 18, 'Treasure', "1 Rupee"),
+    (24, 'D3', 26, 'Treasure', "Octo Chart"),
+    (25, 'D4', 06, 'Treasure', "200 Rupees"),
+    (26, 'D5', 06, 'Triforce', "Triforce Shard"),
+    (27, 'D6', 04, 'Treasure', "Heart Piece"),
+    (28, 'D7', 08, 'Triforce', "Triforce Shard"),
+    (29, 'E1', 11, 'Treasure', "Heart Piece"),
+    (30, 'E2', 30, 'Treasure', "Heart Piece"),
+    (31, 'E3', 03, 'Treasure', "200 Rupees"),
+    (32, 'E4', 14, 'Treasure', "200 Rupees"),
+    (33, 'E5', 01, 'Treasure', "200 Rupees"),
+    (34, 'E6', 17, 'Treasure', "200 Rupees"),
+    (35, 'E7', 15, 'Treasure', "Heart Piece"),
+    (36, 'F1', 07, 'Triforce', "Triforce Shard"),
+    (37, 'F2', 39, 'Treasure', "200 Rupees"),
+    (38, 'F3', 37, 'Treasure', "200 Rupees"),
+    (39, 'F4', 34, 'Treasure', "200 Rupees"),
+    (40, 'F5', 20, 'Treasure', "Heart Piece"),
+    (41, 'F6', 31, 'Treasure', "Heart Piece"),
+    (42, 'F7', 32, 'Treasure', "Sea Hearts Chart"),
+    (43, 'G1', 13, 'Treasure', "Secret Cave Chart"),
+    (44, 'G2', 19, 'Treasure', "Island Hearts Chart"),
+    (45, 'G3', 27, 'Treasure', "200 Rupees"),
+    (46, 'G4', 05, 'Treasure', "Heart Piece"),
+    (47, 'G5', 36, 'Treasure', "200 Rupees"),
+    (48, 'G6', 05, 'Triforce', "Triforce Shard"),
+    (49, 'G7', 33, 'Treasure', "Heart Piece")
+;
+
+-- Other Charts
+--------------------
+CREATE TABLE IF NOT EXISTS `OtherChart`(
+    `number` INTEGER PRIMARY KEY NOT NULL,
+    `location` CHAR(2),
+    `name` VARCHAR(17) NOT NULL,
+    `details` VARCHAR(50) NOT NULL,
+        FOREIGN KEY (`location`) REFERENCES `Location`(`coordinate`)
+);
+CREATE INDEX `other_chart_location` ON
+    `OtherChart`(`location`);
+CREATE UNIQUE INDEX `other_chart_name` ON
+    `OtherChart`(`name`);
+
+INSERT INTO `OtherChart` (
+    `number`, `location`, `name`, `details`
+) VALUES
+    (01, 'A6', "Ghost Ship Chart",    "Clear the Secret Cave"),
+    (02, 'D2', "Tingle's Chart",      "Free Tingle from jail"),
+    (03, NULL, "IN-credible Chart",   "Letter, after Zelda"),
+    (04, 'D3', "Octo Chart",          "Use Treasure Chart 26"),
+    (05, 'A2', "Great Fairy Chart",   "Use Treasure Chart 41"),
+    (06, 'G2', "Island Hearts Chart", "Use Treasure Chart 19"),
+    (07, 'F7', "Sea Hearts Chart",    "Use Treasure Chart 32"),
+    (08, 'G1', "Secret Cave Chart",   "Use Treasure Chart 13"),
+    (09, 'C4', "Light Ring Chart",    "Use Treasure Chart 21"),
+    (10, 'G2', "Platform Chart",      "Clear the Submarine"),
+    (11, NULL, "Beedle's Chart",      "Letter, after Bombs"),
+    (12, 'F7', "Submarine Chart",     "Clear the Secret Cave")
+;
+
+-- Sunken Treasure → Other Charts
+--------------------
+CREATE TABLE IF NOT EXISTS `SunkenChart`(
+    `sunkenTreasureNumber` INTEGER NOT NULL,
+    `otherChartNumber` INTEGER NOT NULL,
+        FOREIGN KEY (`sunkenTreasureNumber`) REFERENCES
+            `SunkenTreasure`(`number`),
+        FOREIGN KEY (`otherChartNumber`) REFERENCES
+            `OtherChart`(`number`)
+);
+CREATE UNIQUE INDEX `sunken_chart_stNum` ON
+    `SunkenChart`(`sunkenTreasureNumber`);
+CREATE UNIQUE INDEX `sunken_other_chart_ocNum` ON
+    `SunkenChart`(`otherChartNumber`);
+CREATE TRIGGER otherChartSunkenTreasureLocation
+BEFORE INSERT ON `SunkenChart`
+BEGIN
+        SELECT RAISE(FAIL, "That Sunken Treasure and Other Chart do not share the same location")
+        FROM (SELECT COUNT(*) AS 'sunk'
+            FROM `SunkenTreasure`
+            INNER JOIN `OtherChart` USING(`location`)
+            WHERE
+                `SunkenTreasure`.`number` = NEW.`sunkenTreasureNumber` AND
+                `OtherChart`.`number` = NEW.`otherChartNumber`) AS 'SunkenChart'
+        WHERE `SunkenChart`.`sunk` != 1;
+END;
+
+INSERT INTO `SunkenChart` (
+    `sunkenTreasureNumber`, `otherChartNumber`
+) VALUES
+    (24, 04), -- D3
+    (02, 05), -- A2
+    (44, 06), -- G2
+    (42, 07), -- F7
+    (43, 08), -- G1
+    (18, 09)  -- C4
 ;
 
 END;


### PR DESCRIPTION
Also a SunkenChart table for mapping a SunkenTreasure to an OtherChart.
A problem I ran into with this was that I wanted to be sure the `location` of the SunkenTreasure and OtherChart were identical before establishing the mapping between the two. Because, the OtherChart and SunkenTreasure location MUST be the same, and there is no easy way to enforce this, I came up with a trigger on the table before insert to check that the locations were the same.

I tried also having a location field on the SunkenChart table itself with foreign keys to both the SunkenTreasure location and the OtherChart location. But this is not allowed since the `location` field in both of those tables are not primary keys nor have unique constraints.